### PR TITLE
♻️ Add option to allow unvalidated MRNs to not stop code execution

### DIFF
--- a/arcus_manifests/generator/generate.py
+++ b/arcus_manifests/generator/generate.py
@@ -18,6 +18,7 @@ def generate_submission_package(
     submission_package_dir,
     seed_file,
     mrn_map_file,
+    allow_unvalidated_mrn,
     generator_list,
 ):
     if "all" in generator_list:
@@ -53,7 +54,10 @@ def generate_submission_package(
         )
     if "participant_crosswalk" in generator_list:
         build_participant_crosswalk_table(
-            participant_list, mrn_map, submission_package_dir
+            participant_list,
+            mrn_map,
+            submission_package_dir,
+            allow_unvalidated_mrn,
         )
 
     if "file" in generator_list:

--- a/arcus_manifests/generator/participant_crosswalk/build_manifest.py
+++ b/arcus_manifests/generator/participant_crosswalk/build_manifest.py
@@ -17,7 +17,7 @@ def validate_mrn(mrn):
     :return: zero-padded, 8 character-long MRN
     :rtype: str
     """
-    if not isinstance(mrn, int) or mrn.isdigit():
+    if not (isinstance(mrn, int) or mrn.isdigit()):
         raise ValueError("MRN must be coercible to integer")
     if len(str(mrn)) > 8:
         raise ValueError("MRNs cannot be longer than 8 characters")

--- a/arcus_manifests/generator/participant_crosswalk/build_manifest.py
+++ b/arcus_manifests/generator/participant_crosswalk/build_manifest.py
@@ -5,12 +5,14 @@ from d3b_cavatica_tools.utils.logging import get_logger
 logger = get_logger(__name__, testing_mode=False)
 
 
-def validate_mrn(mrn):
+def validate_mrn(mrn, warn_only=False):
     """Validate MRNs
 
     Validates that the MRN can be coerced to be integer and that the mrn is no
     greater than 8 characters long, Returned MRN is zero-padded to be 8
-    characters long
+    characters long.
+
+    If warn_only = True, MRNs that do not pass validation are returned as is.
 
     :param mrn: an MRN
     :type mrn: str or int
@@ -18,14 +20,24 @@ def validate_mrn(mrn):
     :rtype: str
     """
     if not (isinstance(mrn, int) or mrn.isdigit()):
-        raise ValueError("MRN must be coercible to integer")
+        if warn_only:
+            logger.warning(f"MRN should be coercible to integer. mrn: {mrn}")
+        else:
+            raise ValueError("MRN must be coercible to integer. mrn: {mrn}")
     if len(str(mrn)) > 8:
-        raise ValueError("MRNs cannot be longer than 8 characters")
+        if warn_only:
+            logger.warning(
+                f"MRN should not be longer than 8 characters. mrn: {mrn}"
+            )
+        else:
+            raise ValueError(
+                "MRNs cannot be longer than 8 characters. mrn: {mrn}"
+            )
     return f"{int(mrn):08}"
 
 
 def build_participant_crosswalk_table(
-    participant_list, mrn_map, submission_package_dir
+    participant_list, mrn_map, submission_package_dir, allow_unvalidated_mrn
 ):
     logger.info("Building Participant Crosswalk Table")
     column_order = [
@@ -35,7 +47,9 @@ def build_participant_crosswalk_table(
         "auth_participant_id",
     ]
     participant_mrn_map = mrn_map[mrn_map["research_id"].isin(participant_list)]
-    participant_mrn_map["mrn"] = participant_mrn_map["mrn"].apply(validate_mrn)
+    participant_mrn_map["mrn"] = participant_mrn_map["mrn"].apply(
+        validate_mrn, allow_unvalidated_mrn
+    )
     participant_mrn_map = participant_mrn_map.rename(
         columns={
             "research_id": "local_participant_id",

--- a/arcus_manifests/generator/participant_crosswalk/build_manifest.py
+++ b/arcus_manifests/generator/participant_crosswalk/build_manifest.py
@@ -17,10 +17,10 @@ def validate_mrn(mrn):
     :return: zero-padded, 8 character-long MRN
     :rtype: str
     """
-    assert (
-        isinstance(mrn, int) or mrn.isdigit()
-    ), "MRN must be coercible to integer"
-    assert len(str(mrn)) > 8, "MRNs cannot be longer than 8 characters"
+    if not isinstance(mrn, int) or mrn.isdigit():
+        raise ValueError("MRN must be coercible to integer")
+    if len(str(mrn)) > 8:
+        raise ValueError("MRNs cannot be longer than 8 characters")
     return f"{int(mrn):08}"
 
 

--- a/arcus_manifests/scripts/cli.py
+++ b/arcus_manifests/scripts/cli.py
@@ -83,6 +83,17 @@ def arcus_manifests(ctx, postgres_connection_url, submission_packager_dir):
     help="CSV file that maps research IDs (C-IDs) to MRNs.",
 )
 @click.option(
+    "-u",
+    "--allow_unvalidated_mrn",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Flag. Should MRNs that do not pass validation be allowed. "
+    "If True, when an mrn fails validation, a warning is shown and execution "
+    "continues. By default, when MRNs fail validation, execution is halted.",
+)
+@click.option(
     "-g",
     "--table_to_generate",
     "generator",
@@ -95,7 +106,9 @@ def arcus_manifests(ctx, postgres_connection_url, submission_packager_dir):
     show_default=True,
 )
 @click.pass_context
-def generate_submission(ctx, seed_file, mrn_map_file, generator):
+def generate_submission(
+    ctx, seed_file, mrn_map_file, allow_unvalidated_mrn, generator
+):
     """
     Generate an ARCUS submission manifest or manifests using a seed
     file_sample_participant mapping.
@@ -105,6 +118,7 @@ def generate_submission(ctx, seed_file, mrn_map_file, generator):
         ctx.obj["submission_packager_dir"],
         seed_file,
         mrn_map_file,
+        allow_unvalidated_mrn,
         generator,
     )
 


### PR DESCRIPTION
# ♻️ Add option to allow unvalidated MRNs to not stop code execution

- [ ] fixup commits are appropriately squashed

Adds option to allow unvalidated MRNs. Also changes `assert` statements to be `raise`d errors.
